### PR TITLE
Cache bbox

### DIFF
--- a/extract/bbox.py
+++ b/extract/bbox.py
@@ -39,8 +39,12 @@ class BBoxMixin(object):
         self.attr['bbox']. The coordinates are assumed to be in the form
         of a comma-seperated string like so: "x0, y0, x1, y1"
 
-    Adds a bbox() method which returns a BBox object."""
+    Adds a bbox read-only bbox property.
+    
+    (See https://docs.python.org/3/library/functions.html#property for more about
+    properties, and a description of how to make this property read/write if desired)."""
 
+    @property
     def bbox(self):
         points = self.attr['bbox'].split(",")
         #box = BBox(points)

--- a/extract/bbox.py
+++ b/extract/bbox.py
@@ -46,6 +46,11 @@ class BBoxMixin(object):
 
     @property
     def bbox(self):
+        #Check if we've already done the work
+        if hasattr(self, "_bbox"):
+            return self._bbox
+        
+        #Nope. Oh well. Let's get it done.
         points = self.attr['bbox'].split(",")
         #box = BBox(points)
         #           ^^^^^^^
@@ -54,4 +59,14 @@ class BBoxMixin(object):
         #          ^^^^^^^
         # Unpacks the list called points into its individual values, then passes these as individual
         # arguments into the constructor
-        return box
+
+        #Don't want to do this malarkey again.
+        self._bbox = box
+        return self._bbox
+
+        # Alternatively:
+        # if not hasattr(self, "_bbox"):
+        #    ... do the work ....
+        #    self._bbox = box
+        #
+        # return self._bbox

--- a/extract/bbox.py
+++ b/extract/bbox.py
@@ -1,16 +1,53 @@
-class BBox:
-    x0 = 0
-    y0 = 0
-    x1 = 0
-    y1 = 0
+class BBox(object):
+    """Represents a bounding box."""
+
+    def __init__(self, x0 = 0, y0 = 0, x1 = 0, y1 = 0):
+        """Create a BBox from two coordinate pairs.
+
+        Keyword arguments:
+        x0, y0 -- Coordinates for the first point.
+        x1, y1 -- Coordinates for the second point.
+
+        All coordinates are cast to floats, which potentially introduces a loss of precision.
+        TODO: investigate whether it would make more sense to use decimal.Decimal to preserve precision
+
+        Returns:
+        BBox object
+
+        This docstring is based on (PEP-257)[https://www.python.org/dev/peps/pep-0257/].
+
+        Curious about what a docstring is for? Try this:
+
+        $ python
+        Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
+        [GCC 8.3.0] on linux
+        Type "help", "copyright", "credits" or "license" for more information.
+        >>> import extract.bbox
+        >>> help(extract.bbox.BBox)
+        >>> help(extract.bbox.BBoxMixin)
+        """
+        self.x0 = float(x0)
+        self.y0 = float(y0)
+        self.x1 = float(x1)
+        self.y1 = float(y1)
 
 
-class BBoxFactoryMixin(object):
-    def get_bbox(self):
-        b = BBox()
-        p = self.attr['bbox'].split(",")
-        b.x0 = float(p[0])
-        b.y0 = float(p[1])
-        b.x1 = float(p[2])
-        b.y1 = float(p[3])
-        return b
+class BBoxMixin(object):
+    """Mixin class for node types which contain a BBox.
+
+    The coordinates for the bbox should be contained in
+        self.attr['bbox']. The coordinates are assumed to be in the form
+        of a comma-seperated string like so: "x0, y0, x1, y1"
+
+    Adds a bbox() method which returns a BBox object."""
+
+    def bbox(self):
+        points = self.attr['bbox'].split(",")
+        #box = BBox(points)
+        #           ^^^^^^^
+        # Creates a BBox object and passes a single argument, a list, which gets assigned to x0  
+        box = BBox(*points)
+        #          ^^^^^^^
+        # Unpacks the list called points into its individual values, then passes these as individual
+        # arguments into the constructor
+        return box

--- a/extract/test/test_bbox.py
+++ b/extract/test/test_bbox.py
@@ -1,16 +1,16 @@
-from extract.bbox import BBoxFactoryMixin
+from extract.bbox import BBoxMixin
 
 
-class TestBboxClass(BBoxFactoryMixin):
+class TestBboxClass(BBoxMixin):
     """A test class to demonstrate BBoxFactoryMixin"""
     attr = {
         'bbox': '459.840,753.697,462.075,765.210'
     }
 
 
-def test_bbox_factory_mixin():
+def test_bbox_mixin():
     t = TestBboxClass()
-    bb = t.get_bbox()
+    bb = t.bbox()
     assert bb.x0 == 459.84
     assert bb.y0 == 753.697
     assert bb.x1 == 462.075

--- a/extract/test/test_bbox.py
+++ b/extract/test/test_bbox.py
@@ -10,7 +10,7 @@ class TestBboxClass(BBoxMixin):
 
 def test_bbox_mixin():
     t = TestBboxClass()
-    bb = t.bbox()
+    bb = t.bbox
     assert bb.x0 == 459.84
     assert bb.y0 == 753.697
     assert bb.x1 == 462.075

--- a/extract/text.py
+++ b/extract/text.py
@@ -1,7 +1,7 @@
-from .bbox import BBoxFactoryMixin
+from .bbox import BBoxMixin
 
 
-class Text(BBoxFactoryMixin, object):
+class Text(BBoxMixin, object):
     """A class containing information from a <text> node"""
     attr = {}
 


### PR DESCRIPTION
This is actually a patch on top of #3; for a clearer view of the difference, see https://github.com/jamezpolley/qld-govt-hansard-extract/pull/1/files

The difference here is that the BBox object is saved the first time it's created, rather than being created afresh each time it's read.

Whether or not this is desirable depends on how you want to use the object. For instance, this caching has the drawback that if you update `attrs['bbox']`, the `_bbox` object will still have the old values cached; you'd have to drop it and parse the new values; so if that's how you want to update the bbox, don't do this.

If you added a setter for the property, that setter could update the attributes on the bbox object, or.. something.