### PR TITLE
Pythonicalize bboxing

### DIFF
--- a/extract/bbox.py
+++ b/extract/bbox.py
@@ -1,16 +1,53 @@
-class BBox:
-    x0 = 0
-    y0 = 0
-    x1 = 0
-    y1 = 0
+class BBox(object):
+    """Represents a bounding box."""
+
+    def __init__(self, x0 = 0, y0 = 0, x1 = 0, y1 = 0):
+        """Create a BBox from two coordinate pairs.
+
+        Keyword arguments:
+        x0, y0 -- Coordinates for the first point.
+        x1, y1 -- Coordinates for the second point.
+
+        All coordinates are cast to floats, which potentially introduces a loss of precision.
+        TODO: investigate whether it would make more sense to use decimal.Decimal to preserve precision
+
+        Returns:
+        BBox object
+
+        This docstring is based on (PEP-257)[https://www.python.org/dev/peps/pep-0257/].
+
+        Curious about what a docstring is for? Try this:
+
+        $ python
+        Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
+        [GCC 8.3.0] on linux
+        Type "help", "copyright", "credits" or "license" for more information.
+        >>> import extract.bbox
+        >>> help(extract.bbox.BBox)
+        >>> help(extract.bbox.BBoxMixin)
+        """
+        self.x0 = float(x0)
+        self.y0 = float(y0)
+        self.x1 = float(x1)
+        self.y1 = float(y1)
 
 
-class BBoxFactoryMixin(object):
-    def get_bbox(self):
-        b = BBox()
-        p = self.attr['bbox'].split(",")
-        b.x0 = float(p[0])
-        b.y0 = float(p[1])
-        b.x1 = float(p[2])
-        b.y1 = float(p[3])
-        return b
+class BBoxMixin(object):
+    """Mixin class for node types which contain a BBox.
+
+    The coordinates for the bbox should be contained in
+        self.attr['bbox']. The coordinates are assumed to be in the form
+        of a comma-seperated string like so: "x0, y0, x1, y1"
+
+    Adds a bbox() method which returns a BBox object."""
+
+    def bbox(self):
+        points = self.attr['bbox'].split(",")
+        #box = BBox(points)
+        #           ^^^^^^^
+        # Creates a BBox object and passes a single argument, a list, which gets assigned to x0  
+        box = BBox(*points)
+        #          ^^^^^^^
+        # Unpacks the list called points into its individual values, then passes these as individual
+        # arguments into the constructor
+        return box

--- a/extract/test/test_bbox.py
+++ b/extract/test/test_bbox.py
@@ -1,16 +1,16 @@
-from extract.bbox import BBoxFactoryMixin
+from extract.bbox import BBoxMixin
 
 
-class TestBboxClass(BBoxFactoryMixin):
+class TestBboxClass(BBoxMixin):
     """A test class to demonstrate BBoxFactoryMixin"""
     attr = {
         'bbox': '459.840,753.697,462.075,765.210'
     }
 
 
-def test_bbox_factory_mixin():
+def test_bbox_mixin():
     t = TestBboxClass()
-    bb = t.get_bbox()
+    bb = t.bbox()
     assert bb.x0 == 459.84
     assert bb.y0 == 753.697
     assert bb.x1 == 462.075

--- a/extract/text.py
+++ b/extract/text.py
@@ -1,7 +1,7 @@
-from .bbox import BBoxFactoryMixin
+from .bbox import BBoxMixin
 
 
-class Text(BBoxFactoryMixin, object):
+class Text(BBoxMixin, object):
     """A class containing information from a <text> node"""
     attr = {}
 


### PR DESCRIPTION
# Trap for new players: Python supports two different kinds of classes, "new style" and "old style".

````python
class BBox:
    pass

class BBoxMixin(BBox):
    pass
````

creates two old-style classes.

````python
class BBox(object):
    pass

class BBoxMixin(BBox):
    pass
````

creates two new-style classes.

I can't remember the differences offhand, but you don't want to use the old-style classes. So I've changed them all to new-style. Always use new style.

# Added docstrings

I've gone overboard with a couple of them. I've included a suggestion on what to do to see what difference the docstring makes in one of them.

nb: most python IDEs will do useful things with the docstrings too, like so:
![docstring](https://user-images.githubusercontent.com/216918/59546930-48ff0c80-8f79-11e9-980c-f6e651da3a6e.png)

# All classes are factories.

so I've taken "factory" out of the class name.

# `*args*` and `**kwargs` are kinda weird.

I'm.. not going to try to explain here. I think you should be able to follow what I did with *points