### PR TITLE
Cache the bbox

### DIFF
--- a/extract/bbox.py
+++ b/extract/bbox.py
@@ -46,6 +46,11 @@ class BBoxMixin(object):
 
     @property
     def bbox(self):
+        #Check if we've already done the work
+        if hasattr(self, "_bbox"):
+            return self._bbox
+        
+        #Nope. Oh well. Let's get it done.
         points = self.attr['bbox'].split(",")
         #box = BBox(points)
         #           ^^^^^^^
@@ -54,4 +59,14 @@ class BBoxMixin(object):
         #          ^^^^^^^
         # Unpacks the list called points into its individual values, then passes these as individual
         # arguments into the constructor
-        return box
+
+        #Don't want to do this malarkey again.
+        self._bbox = box
+        return self._bbox
+
+        # Alternatively:
+        # if not hasattr(self, "_bbox"):
+        #    ... do the work ....
+        #    self._bbox = box
+        #
+        # return self._bbox


### PR DESCRIPTION
This expands on #6 

The difference here is that the BBox object is saved the first time it's created, rather than creating a new object each time the property is read.

Whether or not this is desirable depends on how you want to use the object. For instance, this caching has the drawback that if you update `attrs['bbox']`, the `_bbox` object will still have the old values cached; you'd have to drop it and parse the new values; so if that's how you want to update the bbox, don't do this.

If you added a setter for the property, that setter could update the attributes on the bbox object, or.. something.